### PR TITLE
Set Spain's TLD

### DIFF
--- a/src/country-by-domain-tld.json
+++ b/src/country-by-domain-tld.json
@@ -804,7 +804,7 @@
   },
   {
     "country": "Spain",
-    "tld": null
+    "tld": ".es"
   },
   {
     "country": "SriLanka",


### PR DESCRIPTION
Set Spain domain tld to '.es'