### PR TITLE
Wrong Brazilian language

### DIFF
--- a/src/country-by-languages.json
+++ b/src/country-by-languages.json
@@ -117,7 +117,7 @@
     },
     {
         "country": "Brazil",
-        "language": "German"
+        "language": "Portuguese"
     },
     {
         "country": "British Indian Ocean Territory",


### PR DESCRIPTION
We don't speak German here in Brazil. https://en.wikipedia.org/wiki/Languages_of_Brazil