### PR TITLE
Change capital of Togo from Lom to Lomé

### DIFF
--- a/src/country-by-capital-city.json
+++ b/src/country-by-capital-city.json
@@ -865,7 +865,7 @@
     },
     {
         "country": "Togo",
-        "city": "Lom"
+        "city": "Lomé"
     },
     {
         "country": "Tokelau",


### PR DESCRIPTION
Actual 
"country": "Togo",
 "city": "Lom"

Propose changes:   Correct name of togolese capital is Lomé
"country": "Togo",
 "city": "Lomé"