### PR TITLE
fix truncated names

### DIFF
--- a/src/country-by-capital-city.json
+++ b/src/country-by-capital-city.json
@@ -201,7 +201,7 @@
     },
     {
         "country": "Costa Rica",
-        "city": "San Jos"
+        "city": "San José"
     },
     {
         "country": "Croatia",
@@ -665,7 +665,7 @@
     },
     {
         "country": "Panama",
-        "city": "Ciudad de Panam"
+        "city": "Ciudad de Panamá"
     },
     {
         "country": "Papua New Guinea",
@@ -673,7 +673,7 @@
     },
     {
         "country": "Paraguay",
-        "city": "Asunci"
+        "city": "Asunción"
     },
     {
         "country": "Peru",
@@ -749,7 +749,7 @@
     },
     {
         "country": "Sao Tome and Principe",
-        "city": "S"
+        "city": "São Tomé"
     },
     {
         "country": "Saudi Arabia",


### PR DESCRIPTION
I noticed several capitals containing accent marks or other diacritics were truncated somehow. Here I've restored the ones I could find, including diacritics.