### PR TITLE
Update country-by-capital-city.json: Fixed spelling of "Reykjavík"

### DIFF
--- a/src/country-by-capital-city.json
+++ b/src/country-by-capital-city.json
@@ -389,7 +389,7 @@
     },
     {
         "country": "Iceland",
-        "city": "Reykjav"
+        "city": "Reykjavík"
     },
     {
         "country": "India",


### PR DESCRIPTION
Fixed spelling of Reykjavík, Capital of Iceland