### PR TITLE
Update country-by-languages.json

### DIFF
--- a/src/country-by-languages.json
+++ b/src/country-by-languages.json
@@ -1404,7 +1404,7 @@
             "Ibibio",
             "Ibo",
             "Ijo",
-            "Joruba",
+            "Yoruba",
             "Kanuri",
             "Tiv"
         ]


### PR DESCRIPTION
Changed Joruba to Yoruba. In Nigeria, the correct spelling is Yoruba