### PR TITLE
Update Cambodia

### DIFF
--- a/src/country-by-languages.json
+++ b/src/country-by-languages.json
@@ -1016,10 +1016,7 @@
     {
         "country": "Cambodia",
         "languages": [
-            "Chinese",
-            "Khmer",
-            "T¬öam",
-            "Vietnamese"
+            "Khmer"
         ]
     },
     {


### PR DESCRIPTION
In Cambodia have only one language (Khmer) We doesn't use chinese or vietnamese.