### PR TITLE
Adding JSON cities link to the README list of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ git clone https://github.com/samayo/country-json
 - [Country by Barcode Prefix](https://github.com/samayo/country-json/blob/master/src/country-by-barcode-prefix.json)
 - [Country by Calling Code](https://github.com/samayo/country-json/blob/master/src/country-by-calling-code.json)
 - [Country by Capital City](https://github.com/samayo/country-json/blob/master/src/country-by-capital-city.json)
+- [Country by Cities](https://github.com/samayo/country-json/blob/master/src/country-by-cities.json)
 - [Country by Continent](https://github.com/samayo/country-json/blob/master/src/country-by-continent.json)
 - [Country by Costline](https://github.com/samayo/country-json/blob/master/src/country-by-costline.json)
 - [Country by Currency Name](https://github.com/samayo/country-json/blob/master/src/country-by-currency-name.json)


### PR DESCRIPTION
Adding a link for the added `JSON Cites` file, to the [List of contents](https://github.com/samayo/country-json/blob/master/README.md#list-of-contents-provided-in-json-formats)