### PR TITLE
Nepal 1769 to null

### DIFF
--- a/src/country-by-independence-date.json
+++ b/src/country-by-independence-date.json
@@ -593,7 +593,7 @@
     },
     {
         "country": "Nepal",
-        "independence": 1769
+        "independence": null
     },
     {
         "country": "Netherlands",


### PR DESCRIPTION
Nepal was never under any other country's regime so we have no independence date. The previous date 1769 was the date when unification of Nepal started.