### PR TITLE
Add some missing data for Ivory Coast, North Macedonia, Serbia, and Democratic Republic of Congo

### DIFF
--- a/src/country-by-landlocked.json
+++ b/src/country-by-landlocked.json
@@ -857,7 +857,7 @@
     },
     {
         "country": "The Democratic Republic of Congo",
-        "landlocked": null
+        "landlocked": "0"
     },
     {
         "country": "Togo",

--- a/src/country-by-religion.json
+++ b/src/country-by-religion.json
@@ -420,6 +420,10 @@
         "religion": "Christianity"
     },
     {
+        "country": "Ivory Coast",
+        "landlocked": "Islam"
+    },
+    {
         "country": "Jamaica",
         "religion": "Christianity"
     },
@@ -638,6 +642,10 @@
     {
         "country": "North Korea",
         "religion": "Unaffiliated Religions"
+    },
+    {
+        "country": "North Macedonia",
+        "religion": "Christianity"
     },
     {
         "country": "Northern Mariana Islands",

--- a/src/country-by-yearly-average-temperature.json
+++ b/src/country-by-yearly-average-temperature.json
@@ -764,6 +764,10 @@
         "temperature": 28.9
     },
     {
+        "country": "Serbia",
+        "temperature": 11.4
+    },
+    {
         "country": "Seychelles",
         "temperature": 27.09
     },


### PR DESCRIPTION
Sources:
- [The Democratic Republic of Congo - landlocked](https://en.wikipedia.org/wiki/Landlocked_country#List_of_landlocked_countries_and_landlocked_de_facto_states)
- [North Macedonia - religion](https://en.wikipedia.org/wiki/Religion_in_North_Macedonia)
- [Ivory Coast - religion](https://en.wikipedia.org/wiki/Religion_in_Ivory_Coast)
- [Serbia - temperature](https://en.wikipedia.org/wiki/List_of_countries_by_average_yearly_temperature)
