### PR TITLE
Update Samoa government type

### DIFF
--- a/src/country-by-government-type.json
+++ b/src/country-by-government-type.json
@@ -741,7 +741,7 @@
     },
     {
         "country": "Samoa",
-        "government": "Parlementary Monarchy"
+        "government": "Parliamentary Republic"
     },
     {
         "country": "San Marino",


### PR DESCRIPTION
Government type was listed as parliamentary monarchy, but should be [parliamentary republic](https://en.wikipedia.org/wiki/Samoa)