### PR TITLE
Update Fiji Islands name for consistency and update Barbados government type

### DIFF
--- a/src/country-by-alphabet-letters.json
+++ b/src/country-by-alphabet-letters.json
@@ -197,7 +197,7 @@
     "F": {
       "countries": [
         {
-          "country": "Fiji"
+          "country": "Fiji Islands"
         },
         {
           "country": "Finland"

--- a/src/country-by-government-type.json
+++ b/src/country-by-government-type.json
@@ -73,7 +73,7 @@
     },
     {
         "country": "Barbados",
-        "government": "Constitutional Monarchy"
+        "government": "Republic"
     },
     {
         "country": "Belarus",

--- a/src/country-by-religion.json
+++ b/src/country-by-religion.json
@@ -284,7 +284,7 @@
         "religion": "Christianity"
     },
     {
-        "country": "Fiji",
+        "country": "Fiji Islands",
         "religion": "Christianity"
     },
     {


### PR DESCRIPTION
- The name is Fiji Islands in most of the datasets, so updated these two for consistency
- Barbados government [changed from a monarchy to a republic in 2021](https://en.wikipedia.org/wiki/Government_of_Barbados)

Thank you :)