### PR TITLE
Fix duplicate entry for Cape Verde

### DIFF
--- a/src/country-by-population.json
+++ b/src/country-by-population.json
@@ -156,10 +156,6 @@
         "population": 37057765
     },
     {
-        "country": "Cape Verde",
-        "population": 543767
-    },
-    {
         "country": "Cayman Islands",
         "population": 64174
     },


### PR DESCRIPTION
## Summary
- remove duplicate "Cape Verde" entry in population data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848963869c8832d8d312387bfd5f053